### PR TITLE
Update nodejs

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -17,7 +17,7 @@ components:
           targetPort: 3001
   - name: runtime
     container:
-      image: registry.access.redhat.com/ubi8/nodejs-12:1-45
+      image: registry.access.redhat.com/ubi8/nodejs-14:latest
       memoryLimit: 1024Mi
       mountSources: true
       sourceMapping: /project


### PR DESCRIPTION
nodejs-12:1-45 is a very old build and graded 'F' on the RHCC.  Furthermore, nodejs-12 will only be supported until April 2022.  This updates to nodejs-14:latest to avoid the need for continuous updates to the devfile.